### PR TITLE
implement lists of email addresses - all emails get subscribed to bot…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,7 @@ module "team_spend_anomaly_monitor_response" {
   source  = "./modules/anomaly_monitor_response"
 
   awsID = var.awsID
-  alert_email_address = var.alert_email_address
-  action_email_address = var.action_email_address
+  team_spend_emails = var.team_spend_emails
 }
 
 provider "aws" {
@@ -29,17 +28,8 @@ variable "awsID" {
   type = number
 }
 
-# I guess that these email addresses should have the capacity
-# to be lists - or something? XXX
-
-variable "alert_email_address" {
+variable "team_spend_emails" {
   description = "the email address for alerts"
-  type = string
-}
-
-# it may be desirable for this to be null, or a list? XXX
-
-variable "action_email_address" {
-  description = "the email address for actions"
-  type = string
+  type = list(string)
+  default = [""]
 }

--- a/modules/anomaly_monitor_response/topics.tf
+++ b/modules/anomaly_monitor_response/topics.tf
@@ -2,30 +2,22 @@ resource "aws_sns_topic" "team_spend_alert" {
   name = "team-spend-alert"
 }
 
-#import {
-#  to = aws_sns_topic.team_spend_alert
-#  id = "arn:aws:sns:eu-west-2:${var.awsID}:team-spend-alert.arn"
-#}
-
 resource "aws_sns_topic" "team_spend_action" {
   name = "team-spend_action"
 }
 
-#import {
-#  to = aws_sns_topic.team_spend_action
-#  id = "arn:aws:sns:eu-west-2:0123456789012:team-spend-action"
-#}
-
 resource "aws_sns_topic_subscription" "team_spend_alert_email_subscription" {
+  for_each = {for email in var.team_spend_emails: email => email}
   topic_arn = "arn:aws:sns:eu-west-2:${var.awsID}:team-spend-alert"
   protocol  = "email"
-  endpoint  = "${var.alert_email_address}"
+  endpoint  = each.value
 }
 
 resource "aws_sns_topic_subscription" "team_spend_action_email_subscription" {
+  for_each = {for email in var.team_spend_emails: email => email}
   topic_arn = "arn:aws:sns:eu-west-2:${var.awsID}:team-spend-action"
   protocol  = "email"
-  endpoint  = "${var.action_email_address}"
+  endpoint  = each.value
 }
 
 resource "aws_sns_topic_subscription" "team_spend_action_lambda_subscription" {

--- a/modules/anomaly_monitor_response/variables.tf
+++ b/modules/anomaly_monitor_response/variables.tf
@@ -8,16 +8,10 @@ variable "awsID" {
 # I guess that these email addresses should have the capacity
 # to be lists - or something? XXX
 
-variable "alert_email_address" {
+variable "team_spend_emails" {
   description = "the email address for alerts"
-  type = string
-  default = ""
-}
-
-# it may be desirable for this to be null, or a list? XXX
-
-variable "action_email_address" {
-  description = "the email address for actions"
-  type = string
-  default = ""
+  type = list(string)
+  default = [""]
+#  type = string
+#  default = ""
 }

--- a/notes
+++ b/notes
@@ -251,3 +251,4 @@ export TF_VAR_awsID=778666285893
 tofu plan -out tofu.plan && tofu show tofu.plan > plan.txt
 tofu validate && tofu plan -out tofu.plan && tofu show tofu.plan > plan.txt
 cat plan.txt | more
+export TF_VAR_team_spend_emails='["a@b.c", "d@e.f"]'

--- a/plan.txt
+++ b/plan.txt
@@ -367,12 +367,28 @@ OpenTofu will perform the following actions:
       [32m+[0m[0m tracing_config              = (known after apply)
     }
 
-[1m  # module.team_spend_anomaly_monitor_response.aws_sns_topic_subscription.team_spend_action_email_subscription[0m will be created
+[1m  # module.team_spend_anomaly_monitor_response.aws_sns_topic_subscription.team_spend_action_email_subscription["a@b.c"][0m will be created
 [0m  [32m+[0m[0m resource "aws_sns_topic_subscription" "team_spend_action_email_subscription" {
       [32m+[0m[0m arn                             = (known after apply)
       [32m+[0m[0m confirmation_timeout_in_minutes = 1
       [32m+[0m[0m confirmation_was_authenticated  = (known after apply)
-      [32m+[0m[0m endpoint                        = "alpha@beta.delta"
+      [32m+[0m[0m endpoint                        = "a@b.c"
+      [32m+[0m[0m endpoint_auto_confirms          = false
+      [32m+[0m[0m filter_policy_scope             = (known after apply)
+      [32m+[0m[0m id                              = (known after apply)
+      [32m+[0m[0m owner_id                        = (known after apply)
+      [32m+[0m[0m pending_confirmation            = (known after apply)
+      [32m+[0m[0m protocol                        = "email"
+      [32m+[0m[0m raw_message_delivery            = false
+      [32m+[0m[0m topic_arn                       = "arn:aws:sns:eu-west-2:778666285893:team-spend-action"
+    }
+
+[1m  # module.team_spend_anomaly_monitor_response.aws_sns_topic_subscription.team_spend_action_email_subscription["d@e.f"][0m will be created
+[0m  [32m+[0m[0m resource "aws_sns_topic_subscription" "team_spend_action_email_subscription" {
+      [32m+[0m[0m arn                             = (known after apply)
+      [32m+[0m[0m confirmation_timeout_in_minutes = 1
+      [32m+[0m[0m confirmation_was_authenticated  = (known after apply)
+      [32m+[0m[0m endpoint                        = "d@e.f"
       [32m+[0m[0m endpoint_auto_confirms          = false
       [32m+[0m[0m filter_policy_scope             = (known after apply)
       [32m+[0m[0m id                              = (known after apply)
@@ -399,12 +415,12 @@ OpenTofu will perform the following actions:
       [32m+[0m[0m topic_arn                       = "arn:aws:sns:eu-west-2:778666285893:team-spend-action"
     }
 
-[1m  # module.team_spend_anomaly_monitor_response.aws_sns_topic_subscription.team_spend_alert_email_subscription[0m will be created
+[1m  # module.team_spend_anomaly_monitor_response.aws_sns_topic_subscription.team_spend_alert_email_subscription["a@b.c"][0m will be created
 [0m  [32m+[0m[0m resource "aws_sns_topic_subscription" "team_spend_alert_email_subscription" {
       [32m+[0m[0m arn                             = (known after apply)
       [32m+[0m[0m confirmation_timeout_in_minutes = 1
       [32m+[0m[0m confirmation_was_authenticated  = (known after apply)
-      [32m+[0m[0m endpoint                        = "alpha@beta.delta"
+      [32m+[0m[0m endpoint                        = "a@b.c"
       [32m+[0m[0m endpoint_auto_confirms          = false
       [32m+[0m[0m filter_policy_scope             = (known after apply)
       [32m+[0m[0m id                              = (known after apply)
@@ -415,5 +431,21 @@ OpenTofu will perform the following actions:
       [32m+[0m[0m topic_arn                       = "arn:aws:sns:eu-west-2:778666285893:team-spend-alert"
     }
 
-[1mPlan:[0m 15 to add, 0 to change, 0 to destroy.
+[1m  # module.team_spend_anomaly_monitor_response.aws_sns_topic_subscription.team_spend_alert_email_subscription["d@e.f"][0m will be created
+[0m  [32m+[0m[0m resource "aws_sns_topic_subscription" "team_spend_alert_email_subscription" {
+      [32m+[0m[0m arn                             = (known after apply)
+      [32m+[0m[0m confirmation_timeout_in_minutes = 1
+      [32m+[0m[0m confirmation_was_authenticated  = (known after apply)
+      [32m+[0m[0m endpoint                        = "d@e.f"
+      [32m+[0m[0m endpoint_auto_confirms          = false
+      [32m+[0m[0m filter_policy_scope             = (known after apply)
+      [32m+[0m[0m id                              = (known after apply)
+      [32m+[0m[0m owner_id                        = (known after apply)
+      [32m+[0m[0m pending_confirmation            = (known after apply)
+      [32m+[0m[0m protocol                        = "email"
+      [32m+[0m[0m raw_message_delivery            = false
+      [32m+[0m[0m topic_arn                       = "arn:aws:sns:eu-west-2:778666285893:team-spend-alert"
+    }
+
+[1mPlan:[0m 17 to add, 0 to change, 0 to destroy.
 [0m


### PR DESCRIPTION
single email refers to the consolidation of the alert_email_address and action_email_address into a single team_spend_emails.

However, team_spend_emails is a list of email addresses to allow many subscribers.

Sorry for any semantic  confusion.

As ever, notes is updated with the necessary env variable change